### PR TITLE
Start to be less assertive in the code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@
    - 18.2
 
  elixir:
-   - 1.1.0
    - 1.2.0
 
  sudo: false

--- a/lib/dicon/executor.ex
+++ b/lib/dicon/executor.ex
@@ -86,7 +86,7 @@ defmodule Dicon.Executor do
     end
   end
 
-  defp raise_error(executor_mod, reason) when is_binary(reason) do
-    Mix.raise "(in #{inspect executor_mod}) " <> reason
+  defp raise_error(executor, reason) when is_binary(reason) do
+    Mix.raise "(in #{inspect executor}) " <> reason
   end
 end

--- a/lib/dicon/executor.ex
+++ b/lib/dicon/executor.ex
@@ -12,20 +12,22 @@ defmodule Dicon.Executor do
   Connects to the given authority, returning a term that identifies the
   connection.
   """
-  @callback connect(authority :: binary) :: {:ok, identifier} | {:error, term}
+  @callback connect(authority :: binary) :: {:ok, identifier} | {:error, binary}
 
   @doc """
   Executes the given `command` on the given connection.
   """
-  @callback exec(identifier, command :: char_list) :: :ok
+  @callback exec(identifier, command :: char_list) :: :ok | {:error, binary}
 
   @doc """
   Copies the local file `source` over to the destination `target` on the given
   connection.
   """
-  @callback copy(identifier, source :: char_list, target :: char_list) :: :ok
+  @callback copy(identifier, source :: char_list, target :: char_list) :: :ok | {:error, binary}
 
-  defstruct [:module, :ref]
+  @type t :: %__MODULE__{executor: module, id: identifier}
+
+  defstruct [:executor, :id]
 
   @doc """
   Connects to authority.
@@ -39,10 +41,13 @@ defmodule Dicon.Executor do
       %Dicon.Executor{} = Dicon.Executor.connect("meg:secret@example.com")
 
   """
+  @spec connect(binary) :: {:ok, t} | {:error, term}
   def connect(authority) do
-    module = Application.get_env(:dicon, :executor, SecureShell)
-    {:ok, ref} = module.connect(authority)
-    %__MODULE__{module: module, ref: ref}
+    executor = Application.get_env(:dicon, :executor, SecureShell)
+    case executor.connect(authority) do
+      {:ok, id}        -> %__MODULE__{executor: executor, id: id}
+      {:error, reason} -> raise_error(executor, reason)
+    end
   end
 
   @doc """
@@ -56,7 +61,7 @@ defmodule Dicon.Executor do
 
   """
   def exec(%__MODULE__{} = state, command) do
-    :ok = run(state, :exec, [command])
+    run(state, :exec, [command])
   end
 
   @doc """
@@ -71,10 +76,17 @@ defmodule Dicon.Executor do
 
   """
   def copy(%__MODULE__{} = state, source, target) do
-    :ok = run(state, :copy, [source, target])
+    run(state, :copy, [source, target])
   end
 
-  defp run(%{module: module, ref: ref}, fun, args) do
-    apply(module, fun, [ref | args])
+  defp run(%{executor: executor, id: id}, fun, args) do
+    case apply(executor, fun, [id | args]) do
+      {:error, reason} -> raise_error(executor, reason)
+      :ok              -> :ok
+    end
+  end
+
+  defp raise_error(executor_mod, reason) when is_binary(reason) do
+    Mix.raise "(in #{inspect executor_mod}) " <> reason
   end
 end

--- a/lib/mix/tasks/dicon.control.ex
+++ b/lib/mix/tasks/dicon.control.ex
@@ -41,6 +41,6 @@ defmodule Mix.Tasks.Dicon.Control do
   defp exec(conn, target_dir, command) do
     otp_app = config(:otp_app) |> Atom.to_string
     command = [target_dir, "/current/bin/", otp_app, ?\s, command]
-    :ok = Executor.exec(conn, command)
+    Executor.exec(conn, command)
   end
 end

--- a/lib/mix/tasks/dicon.deploy.ex
+++ b/lib/mix/tasks/dicon.deploy.ex
@@ -44,20 +44,20 @@ defmodule Mix.Tasks.Dicon.Deploy do
   end
 
   defp ensure_dir(conn, path) do
-    :ok = Executor.exec(conn, ["mkdir -p ", path])
+    Executor.exec(conn, ["mkdir -p ", path])
   end
 
   defp upload(conn, source, target_dir) do
-    :ok = ensure_dir(conn, target_dir)
+    ensure_dir(conn, target_dir)
     release_file = [target_dir, "/release.tar.gz"]
-    :ok = Executor.copy(conn, source, release_file)
+    Executor.copy(conn, source, release_file)
     release_file
   end
 
   defp unpack(conn, release_file, target_dir) do
-    :ok = ensure_dir(conn, target_dir)
+    ensure_dir(conn, target_dir)
     command = ["tar -C ", target_dir, " -zxf ", release_file]
-    :ok = Executor.exec(conn, command)
-    :ok = Executor.exec(conn, ["rm ", release_file])
+    Executor.exec(conn, command)
+    Executor.exec(conn, ["rm ", release_file])
   end
 end

--- a/lib/mix/tasks/dicon.switch.ex
+++ b/lib/mix/tasks/dicon.switch.ex
@@ -28,6 +28,6 @@ defmodule Mix.Tasks.Dicon.Switch do
 
   defp symlink(conn, source, target) do
     command = ["ln -snf ", source, ?\s, target]
-    :ok = Executor.exec(conn, command)
+    Executor.exec(conn, command)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Dicon.Mixfile do
   def project() do
     [app: :dicon,
      version: "0.3.0",
-     elixir: "~> 1.1",
+     elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      package: package(),

--- a/test/dicon/executor_test.exs
+++ b/test/dicon/executor_test.exs
@@ -1,0 +1,48 @@
+defmodule Dicon.ExecutorTest do
+  use ExUnit.Case
+
+  alias Dicon.Executor
+
+  defmodule FakeExecutor do
+    @behaviour Executor
+
+    def connect(:fail), do: {:error, "connect failed"}
+    def connect(term), do: {:ok, term}
+
+    def exec(_conn, :fail), do: {:error, "exec failed"}
+    def exec(_conn, _command), do: :ok
+
+    def copy(_conn, :fail, :fail), do: {:error, "copy failed"}
+    def copy(_conn, _source, _target), do: :ok
+  end
+
+  setup_all do
+    Application.put_env(:dicon, :executor, FakeExecutor)
+    on_exit(fn -> Application.delete_env(:dicon, :executor) end)
+  end
+
+  test "connect/1" do
+    assert %Executor{} = Executor.connect(:whatever)
+
+    message = "(in Dicon.ExecutorTest.FakeExecutor) connect failed"
+    assert_raise Mix.Error, message, fn -> Executor.connect(:fail) end
+  end
+
+  test "exec/2" do
+    conn = Executor.connect(:whatever)
+
+    assert Executor.exec(conn, :whatever) == :ok
+
+    message = "(in Dicon.ExecutorTest.FakeExecutor) exec failed"
+    assert_raise Mix.Error, message, fn -> Executor.exec(conn, :fail) end
+  end
+
+  test "copy/2" do
+    conn = Executor.connect(:whatever)
+
+    assert Executor.copy(conn, :source, :target) == :ok
+
+    message = "(in Dicon.ExecutorTest.FakeExecutor) copy failed"
+    assert_raise Mix.Error, message, fn -> Executor.copy(conn, :fail, :fail) end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,21 +36,21 @@ defmodule DiconTest.Case do
   end
 
   def connect(authority) do
-    ref = make_ref()
-    notify_test({:dicon, ref, :connect, [authority]})
-    {:ok, ref}
+    id = make_ref()
+    notify_test({:dicon, id, :connect, [authority]})
+    {:ok, id}
   end
 
-  def exec(ref, command) do
+  def exec(id, command) do
     command = List.to_string(command)
-    notify_test({:dicon, ref, :exec, [command]})
+    notify_test({:dicon, id, :exec, [command]})
     :ok
   end
 
-  def copy(ref, source, target) do
+  def copy(id, source, target) do
     source = List.to_string(source)
     target = List.to_string(target)
-    notify_test({:dicon, ref, :copy, [source, target]})
+    notify_test({:dicon, id, :copy, [source, target]})
     :ok
   end
 


### PR DESCRIPTION
@lexmag this PR is very rough but I wanted to get early feedback from you. I feel like we should never raise `Mix.Error` exceptions outside of `Mix.*` modules; actually, we should probably never raise any exception outside of those modules. As a safety measure for enforcing this, we could wrap all Mix tasks in `try`s and reraise the original exception as a `Mix.Error` (useful for stuff like `File.stat!`, where the exception message is useful and we can leverage it). What do you think about this?

One small note: I used `with` a couple of times even if we require `~> 1.1` in Mix. Do we actually require that or can we bump the requirement over to `1.2`? I can get rid of the `with`s of course.
