### PR TITLE
Allow parallel deployments

### DIFF
--- a/lib/dicon/secure_shell.ex
+++ b/lib/dicon/secure_shell.ex
@@ -104,7 +104,7 @@ defmodule Dicon.SecureShell do
     {user, passwd, host, port}
   end
 
-  def exec(%__MODULE__{} = state, command, device) do
+  def exec(%__MODULE__{} = state, _silent, command, device) do
     %{conn: conn, connect_timeout: connect_timeout, exec_timeout: exec_timeout} = state
 
     result =
@@ -130,11 +130,11 @@ defmodule Dicon.SecureShell do
     end
   end
 
-  def write_file(%__MODULE__{} = state, target, content, :append) do
+  def write_file(%__MODULE__{} = state, _silent, target, content, :append) do
     write_file(state, ["cat >> ", target], content)
   end
 
-  def write_file(%__MODULE__{} = state, target, content, :write) do
+  def write_file(%__MODULE__{} = state, _silent, target, content, :write) do
     write_file(state, ["cat > ", target], content)
   end
 
@@ -151,7 +151,7 @@ defmodule Dicon.SecureShell do
     format_if_error(result)
   end
 
-  def copy(%__MODULE__{} = state, source, target) do
+  def copy(%__MODULE__{} = state, silent, source, target) do
     %{conn: conn, connect_timeout: connect_timeout, exec_timeout: exec_timeout} = state
 
     result =
@@ -164,7 +164,9 @@ defmodule Dicon.SecureShell do
              # TODO: we need to remove this assertion here as well, once we have a
              # better "streaming" API.
              :ok = :ssh_connection.send(conn, channel, chunk, exec_timeout)
-             write_spinner(chunk_index, chunk_count)
+             unless silent do
+               write_spinner(chunk_index, chunk_count)
+             end
            end),
            IO.write(IO.ANSI.format([:clear_line, ?\r])),
            :ok <- :ssh_connection.send_eof(conn, channel),

--- a/lib/dicon/secure_shell.ex
+++ b/lib/dicon/secure_shell.ex
@@ -168,7 +168,7 @@ defmodule Dicon.SecureShell do
                write_spinner(chunk_index, chunk_count)
              end
            end),
-           IO.write(IO.ANSI.format([:clear_line, ?\r])),
+           (unless silent, do: IO.write(IO.ANSI.format([:clear_line, ?\r]))),
            :ok <- :ssh_connection.send_eof(conn, channel),
            do: handle_reply(conn, channel, Process.group_leader(), exec_timeout, _acc = [])
 

--- a/lib/mix/tasks/dicon.control.ex
+++ b/lib/mix/tasks/dicon.control.ex
@@ -48,6 +48,6 @@ defmodule Mix.Tasks.Dicon.Control do
           [key, ?=, inspect(value, binaries: :as_strings), ?\s]
       end)
     command = env ++ [target_dir, "/current/bin/", otp_app, ?\s, command]
-    Executor.exec(conn, command)
+    Executor.exec(conn, false, command)
   end
 end

--- a/lib/mix/tasks/dicon.deploy.ex
+++ b/lib/mix/tasks/dicon.deploy.ex
@@ -60,6 +60,12 @@ defmodule Mix.Tasks.Dicon.Deploy do
     end
   end
 
+  defp parallel_deploy([first], target_dir, version, source, opts) do
+    timeout = Keyword.get(opts, :timeout, :infinity)
+    task = Task.async(fn -> deploy(first, source, target_dir, version, false) end)
+    Task.await(task, timeout)
+  end
+
   defp parallel_deploy(hosts, target_dir, version, source, opts) do
     timeout = Keyword.get(opts, :timeout, :infinity)
     [first | hosts] = hosts

--- a/lib/mix/tasks/dicon.deploy.ex
+++ b/lib/mix/tasks/dicon.deploy.ex
@@ -9,7 +9,18 @@ defmodule Mix.Tasks.Dicon.Deploy do
   The configured hosts are picked up from the application's configuration; read
   the `Dicon` documentation for more information.
 
-  This task accepts two arguments: the compressed tarball to upload and its version.
+  This task accepts two arguments: the compressed tarball to upload and its version. There are
+  also two flags that can be passed to configure uploading the tarball to multiple hosts in
+  parallel.
+
+  ## Flags
+
+    This command supports the following CLI flags:
+
+    * `--parallel` - boolean flag that will enable uploading the compressed tarball in parallel to all hosts.
+    * `--timeout` - the value in milliseconds for a timeout for each async upload. Defaults to `:infinity`.
+
+    `--timeout` is ignored if it is passed without `--parallel`.
 
   ## Usage
 
@@ -18,6 +29,8 @@ defmodule Mix.Tasks.Dicon.Deploy do
   ## Examples
 
       mix dicon.deploy my_app.tar.gz 1.0.0
+      mix dicon.deploy --parallel my_app.tar.gz 1.0.0
+      mix dicon.deploy my_app.tar.gz 1.0.0 --parallel --timeout 36000
 
   """
 

--- a/lib/mix/tasks/dicon.switch.ex
+++ b/lib/mix/tasks/dicon.switch.ex
@@ -52,6 +52,6 @@ defmodule Mix.Tasks.Dicon.Switch do
 
   defp symlink(conn, source, target) do
     command = ["ln -snf ", source, ?\s, target]
-    Executor.exec(conn, command)
+    Executor.exec(conn, false, command)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,7 @@ defmodule Dicon.Mixfile do
 
   defp package() do
     [maintainers: ["Aleksei Magusev", "Andrea Leopardi"],
+    files: ~w(lib mix.exs README.md CHANGELOG.md LICENSE),
      licenses: ["ISC"],
      links: %{"GitHub" => "https://github.com/lexmag/dicon"}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,4 @@
-%{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+%{
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm", "59514c4a207f9f25c5252e09974367718554b6a0f41fe39f7dc232168f9cb309"},
+  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "b6fb4aef8125c62e6b6a7d7507eff70f376a7050c7745af11f08333ea9beebd3"},
+}

--- a/test/dicon/executor_test.exs
+++ b/test/dicon/executor_test.exs
@@ -9,14 +9,14 @@ defmodule Dicon.ExecutorTest do
     def connect("fail"), do: {:error, "connect failed"}
     def connect(term), do: {:ok, term}
 
-    def exec(_conn, 'fail', _device), do: {:error, "exec failed"}
-    def exec(_conn, _command, _device), do: :ok
+    def exec(_conn, _silent, 'fail', _device), do: {:error, "exec failed"}
+    def exec(_conn, _silent, _command, _device), do: :ok
 
-    def write_file(_conn, 'fail', "fail", _mode), do: {:error, "write failed"}
-    def write_file(_conn, _target, _content, _mode), do: :ok
+    def write_file(_conn, _silent, 'fail', "fail", _mode), do: {:error, "write failed"}
+    def write_file(_conn, _silent, _target, _content, _mode), do: :ok
 
-    def copy(_conn, 'fail', 'fail'), do: {:error, "copy failed"}
-    def copy(_conn, _source, _target), do: :ok
+    def copy(_conn, _silent, 'fail', 'fail'), do: {:error, "copy failed"}
+    def copy(_conn, _silent, _source, _target), do: :ok
   end
 
   setup_all do
@@ -32,35 +32,35 @@ defmodule Dicon.ExecutorTest do
     assert_raise Mix.Error, message, fn -> Executor.connect("fail") end
   end
 
-  test "exec/2" do
+  test "exec/3" do
     conn = Executor.connect("whatever")
 
-    assert Executor.exec(conn, "whatever") == :ok
+    assert Executor.exec(conn, false, "whatever") == :ok
     assert_receive {:mix_shell, :info, ["==> EXEC whatever"]}
 
     message = "(in Dicon.ExecutorTest.FakeExecutor) exec failed"
-    assert_raise Mix.Error, message, fn -> Executor.exec(conn, 'fail') end
+    assert_raise Mix.Error, message, fn -> Executor.exec(conn, false, 'fail') end
   end
 
-  test "copy/2" do
+  test "copy/3" do
     conn = Executor.connect("whatever")
 
-    assert Executor.copy(conn, 'source', 'target') == :ok
+    assert Executor.copy(conn, false, 'source', 'target') == :ok
     assert_receive {:mix_shell, :info, ["==> COPY source target"]}
 
     message = "(in Dicon.ExecutorTest.FakeExecutor) copy failed"
-    assert_raise Mix.Error, message, fn -> Executor.copy(conn, 'fail', 'fail') end
+    assert_raise Mix.Error, message, fn -> Executor.copy(conn, false, 'fail', 'fail') end
   end
 
-  test "write_file/4" do
+  test "write_file/5" do
     conn = Executor.connect("whatever")
 
-    assert Executor.write_file(conn, 'target', "content") == :ok
+    assert Executor.write_file(conn, false, 'target', "content") == :ok
     assert_receive {:mix_shell, :info, ["==> WRITE target"]}
 
     message = "(in Dicon.ExecutorTest.FakeExecutor) write failed"
     assert_raise Mix.Error, message, fn ->
-      Executor.write_file(conn, 'fail', "fail")
+      Executor.write_file(conn, false, 'fail', "fail")
     end
   end
 end

--- a/test/mix/tasks/dicon.control_test.exs
+++ b/test/mix/tasks/dicon.control_test.exs
@@ -4,13 +4,13 @@ defmodule Mix.Tasks.Dicon.ControlTest do
   import Mix.Tasks.Dicon.Control, only: [run: 1]
 
   setup do
-    config = %{
+    config = [
       otp_app: :sample,
       target_dir: "test",
       hosts: [:one, :two],
       one: [authority: "one"],
       two: [authority: "two"],
-    }
+    ]
     Mix.Config.persist(dicon: config)
     :ok
   end
@@ -19,22 +19,22 @@ defmodule Mix.Tasks.Dicon.ControlTest do
     run(["run"])
 
     assert_receive {:dicon, ref, :connect, ["one"]}
-    assert_receive {:dicon, ^ref, :exec, ["test/current/bin/sample run"]}
+    assert_receive {:dicon, ^ref, :exec, ["test/current/bin/sample run", false]}
 
     assert_receive {:dicon, ref, :connect, ["two"]}
-    assert_receive {:dicon, ^ref, :exec, ["test/current/bin/sample run"]}
+    assert_receive {:dicon, ^ref, :exec, ["test/current/bin/sample run", false]}
 
     refute_receive {:dicon, _, _, _}
   end
 
   test "hosts filtering" do
-    config = %{
+    config = [
       otp_app: :sample,
       target_dir: "test",
       hosts: [:one, :two],
       one: [authority: "one"],
       two: [authority: "two"],
-    }
+    ]
     Mix.Config.persist(dicon: config)
 
     run(["run", "--only", "one"])
@@ -78,16 +78,16 @@ defmodule Mix.Tasks.Dicon.ControlTest do
   end
 
   test "OS environment" do
-    config = %{
+    config = [
       otp_app: :sample,
       target_dir: "test",
       hosts: [:one],
       one: [authority: "one", os_env: %{"IS_FOO" => "yes it is", "BAR" => "baz\"bong"}],
-    }
+    ]
     Mix.Config.persist(dicon: config)
 
     run(["run"])
     assert_receive {:dicon, ref, :connect, ["one"]}
-    assert_receive {:dicon, ^ref, :exec, [~S(BAR="baz\"bong" IS_FOO="yes it is" test/current/bin/sample run)]}
+    assert_receive {:dicon, ^ref, :exec, [~S(BAR="baz\"bong" IS_FOO="yes it is" test/current/bin/sample run), false]}
   end
 end

--- a/test/mix/tasks/dicon.deploy_test.exs
+++ b/test/mix/tasks/dicon.deploy_test.exs
@@ -60,13 +60,13 @@ defmodule Mix.Tasks.Dicon.DeployTest do
     run(["--parallel", "--timeout", "36000", source, "0.1.0"])
 
     assert_receive {:dicon, ref, :connect, ["one"]}
-    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test", true]}
-    assert_receive {:dicon, ^ref, :copy, [^source, ^release_file, true]}
-    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test/0.1.0", true]}
-    assert_receive {:dicon, ^ref, :exec, ["tar -C test/0.1.0 -zxf " <> ^release_file, true]}
-    assert_receive {:dicon, ^ref, :exec, ["rm " <> ^release_file, true]}
-    assert_receive {:dicon, ^ref, :exec, ["cat test/0.1.0/releases/0.1.0/sys.config", true]}
-    assert_receive {:dicon, ^ref, :write_file, ["test/0.1.0/releases/0.1.0/sys.config", "[{foo,[{qux,<<\"baz\">>},{bar,<<\"baz\">>}]}].\n", :write, true]}
+    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test", false]}
+    assert_receive {:dicon, ^ref, :copy, [^source, ^release_file, false]}
+    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test/0.1.0", false]}
+    assert_receive {:dicon, ^ref, :exec, ["tar -C test/0.1.0 -zxf " <> ^release_file, false]}
+    assert_receive {:dicon, ^ref, :exec, ["rm " <> ^release_file, false]}
+    assert_receive {:dicon, ^ref, :exec, ["cat test/0.1.0/releases/0.1.0/sys.config", false]}
+    assert_receive {:dicon, ^ref, :write_file, ["test/0.1.0/releases/0.1.0/sys.config", "[{foo,[{qux,<<\"baz\">>},{bar,<<\"baz\">>}]}].\n", :write, false]}
 
     assert_receive {:dicon, ref, :connect, ["two"]}
     assert_receive {:dicon, ^ref, :exec, ["mkdir -p test", true]}

--- a/test/mix/tasks/dicon.deploy_test.exs
+++ b/test/mix/tasks/dicon.deploy_test.exs
@@ -57,7 +57,7 @@ defmodule Mix.Tasks.Dicon.DeployTest do
       IO.write(device, "[{foo,[{qux,<<\"baz\">>}]}].\n")
     end)
 
-    run([source, "0.1.0", "--parallel", "--timeout", "36000"])
+    run(["--parallel", "--timeout", "36000", source, "0.1.0"])
 
     assert_receive {:dicon, ref, :connect, ["one"]}
     assert_receive {:dicon, ^ref, :exec, ["mkdir -p test", true]}

--- a/test/mix/tasks/dicon.deploy_test.exs
+++ b/test/mix/tasks/dicon.deploy_test.exs
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Dicon.DeployTest do
   import Mix.Tasks.Dicon.Deploy, only: [run: 1]
 
   setup_all do
-    config = %{
+    config = [
       target_dir: "test",
       hosts: [:one, :two],
       one: [
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Dicon.DeployTest do
       two: [
         authority: "two",
       ],
-    }
+    ]
     Mix.Config.persist(dicon: config)
     :ok
   end
@@ -31,20 +31,20 @@ defmodule Mix.Tasks.Dicon.DeployTest do
     run([source, "0.1.0"])
 
     assert_receive {:dicon, ref, :connect, ["one"]}
-    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test"]}
-    assert_receive {:dicon, ^ref, :copy, [^source, ^release_file]}
-    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test/0.1.0"]}
-    assert_receive {:dicon, ^ref, :exec, ["tar -C test/0.1.0 -zxf " <> ^release_file]}
-    assert_receive {:dicon, ^ref, :exec, ["rm " <> ^release_file]}
-    assert_receive {:dicon, ^ref, :exec, ["cat test/0.1.0/releases/0.1.0/sys.config"]}
-    assert_receive {:dicon, ^ref, :write_file, ["test/0.1.0/releases/0.1.0/sys.config", "[{foo,[{qux,<<\"baz\">>},{bar,<<\"baz\">>}]}].\n", :write]}
+    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test", false]}
+    assert_receive {:dicon, ^ref, :copy, [^source, ^release_file, false]}
+    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test/0.1.0", false]}
+    assert_receive {:dicon, ^ref, :exec, ["tar -C test/0.1.0 -zxf " <> ^release_file, false]}
+    assert_receive {:dicon, ^ref, :exec, ["rm " <> ^release_file, false]}
+    assert_receive {:dicon, ^ref, :exec, ["cat test/0.1.0/releases/0.1.0/sys.config", false]}
+    assert_receive {:dicon, ^ref, :write_file, ["test/0.1.0/releases/0.1.0/sys.config", "[{foo,[{qux,<<\"baz\">>},{bar,<<\"baz\">>}]}].\n", :write, false]}
 
     assert_receive {:dicon, ref, :connect, ["two"]}
-    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test"]}
-    assert_receive {:dicon, ^ref, :copy, [^source, ^release_file]}
-    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test/0.1.0"]}
-    assert_receive {:dicon, ^ref, :exec, ["tar -C test/0.1.0 -zxf " <> ^release_file]}
-    assert_receive {:dicon, ^ref, :exec, ["rm " <> ^release_file]}
+    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test", false]}
+    assert_receive {:dicon, ^ref, :copy, [^source, ^release_file, false]}
+    assert_receive {:dicon, ^ref, :exec, ["mkdir -p test/0.1.0", false]}
+    assert_receive {:dicon, ^ref, :exec, ["tar -C test/0.1.0 -zxf " <> ^release_file, false]}
+    assert_receive {:dicon, ^ref, :exec, ["rm " <> ^release_file, false]}
 
     refute_receive {:dicon, _, _, _}
   end

--- a/test/mix/tasks/dicon.switch_test.exs
+++ b/test/mix/tasks/dicon.switch_test.exs
@@ -4,48 +4,48 @@ defmodule Mix.Tasks.Dicon.SwitchTest do
   import Mix.Tasks.Dicon.Switch, only: [run: 1]
 
   test "relative path" do
-    config = %{
+    config = [
       target_dir: "test",
       hosts: [:one, :two],
       one: [authority: "one"],
       two: [authority: "two"],
-    }
+    ]
     Mix.Config.persist(dicon: config)
 
     run(["0.1.0"])
 
     assert_receive {:dicon, ref, :connect, ["one"]}
-    assert_receive {:dicon, ^ref, :exec, ["ln -snf $PWD/test/0.1.0 $PWD/test/current"]}
+    assert_receive {:dicon, ^ref, :exec, ["ln -snf $PWD/test/0.1.0 $PWD/test/current", false]}
 
     assert_receive {:dicon, ref, :connect, ["two"]}
-    assert_receive {:dicon, ^ref, :exec, ["ln -snf $PWD/test/0.1.0 $PWD/test/current"]}
+    assert_receive {:dicon, ^ref, :exec, ["ln -snf $PWD/test/0.1.0 $PWD/test/current", false]}
 
     refute_receive {:dicon, _, _, _}
   end
 
   test "absolute path" do
-    config = %{
+    config = [
       target_dir: "/home/test",
       hosts: [:one],
       one: [authority: "one"],
-    }
+    ]
     Mix.Config.persist(dicon: config)
 
     run(["0.2.0"])
 
     assert_receive {:dicon, ref, :connect, ["one"]}
-    assert_receive {:dicon, ^ref, :exec, ["ln -snf /home/test/0.2.0 /home/test/current"]}
+    assert_receive {:dicon, ^ref, :exec, ["ln -snf /home/test/0.2.0 /home/test/current", false]}
 
     refute_receive {:dicon, _, _, _}
   end
 
   test "hosts filtering" do
-    config = %{
+    config = [
       target_dir: "test",
       hosts: [:one, :two],
       one: [authority: "one"],
       two: [authority: "two"],
-    }
+    ]
     Mix.Config.persist(dicon: config)
 
     run(["0.2.0", "--only", "one"])

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -43,24 +43,24 @@ defmodule DiconTest.Case do
     {:ok, conn}
   end
 
-  def exec(conn, command, device) do
+  def exec(conn, silent, command, device) do
     command = List.to_string(command)
     run_callback(command, device)
-    notify_test({:dicon, conn, :exec, [command]})
+    notify_test({:dicon, conn, :exec, [command, silent]})
     :ok
   end
 
-  def write_file(conn, target, content, mode) do
+  def write_file(conn, silent, target, content, mode) do
     content = IO.iodata_to_binary(content)
     target = List.to_string(target)
-    notify_test({:dicon, conn, :write_file, [target, content, mode]})
+    notify_test({:dicon, conn, :write_file, [target, content, mode, silent]})
     :ok
   end
 
-  def copy(conn, source, target) do
+  def copy(conn, silent, source, target) do
     source = List.to_string(source)
     target = List.to_string(target)
-    notify_test({:dicon, conn, :copy, [source, target]})
+    notify_test({:dicon, conn, :copy, [source, target, silent]})
     :ok
   end
 


### PR DESCRIPTION
This PR is a WIP at the moment, but it will add the ability to execute deployments in
parallel. This is configured with a CLI flag, and there's also a CLI flag that will allow
users to configure a timeout for each of these parallel deployments.

The basics are there for allowing more actions to be taken in parallel, but they're not
really used at the moment. I figured the actual copying of the tarball to the remote
host is usually the most time consuming part of the process, and so this seemed
like a reasonable place to start off.